### PR TITLE
CHORE: removes puts on monkey patch

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="ruby-2.6.3-p62" project-jdk-type="RUBY_SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/money-date-exchange-bank.iml" filepath="$PROJECT_DIR$/.idea/money-date-exchange-bank.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/money-date-exchange-bank.iml
+++ b/.idea/money-date-exchange-bank.iml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="RUBY_MODULE" version="4">
+  <component name="ModuleRunConfigurationManager">
+    <shared />
+  </component>
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/features" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="PROVIDED" name="bundler (v1.17.2, ruby-2.6.3-p62) [gem]" level="application" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/lib/money/extensions/money.rb
+++ b/lib/money/extensions/money.rb
@@ -6,7 +6,6 @@ module Extensions
   # MonkeyPatch of the Money class to allow for exchange_to with date or rate.
   module Money
     def self.included(base)
-      puts 'Overriding Money#exchange_to, original method available as Money#orig_exchange_to.'
       base.class_eval do
         alias_method :orig_exchange_to, :exchange_to
         def exchange_to(other_currency, date: nil, rate: nil, &rounding_method)


### PR DESCRIPTION
removes puts on older monkey patch so that it doesn't get printed in the console constantly. If we decide we still want a warning somewhere we could move it to a logger instead